### PR TITLE
ci: update ci to use ctlptl to create a cluster

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,8 @@ jobs:
       - image: tiltdev/tilt:latest
 
     steps:
-      - setup_remote_docker
       - checkout
+      - setup_remote_docker:
+          version: 19.03.12
       - run: apt install -y python
-      - run: with-kind-cluster.sh test/test.sh
+      - run: ctlptl create cluster kind --registry=ctlptl-registry && test/test.sh


### PR DESCRIPTION
Hello @nicks,

Please review the following commits I made in branch nicks/ci:

d6aaa6d0cdffaa08b89553eef53694326fa0703d (2021-03-19 18:57:27 -0400)
ci: update ci to use ctlptl to create a cluster

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics