### PR TITLE
make nodemon detect mustache file changes

### DIFF
--- a/3-recommended/Tiltfile
+++ b/3-recommended/Tiltfile
@@ -17,7 +17,7 @@ local_resource(
 congrats = "🎉 Congrats, you ran a live_update! 🎉"
 docker_build('example-nodejs-image', '.',
     build_args={'node_env': 'development'},
-    entrypoint='yarn run nodemon /app/index.js',
+    entrypoint='yarn run nodemon --ext js,mustache /app/index.js',
     live_update=[
         sync('.', '/app'),
         run('cd /app && yarn install', trigger=['./package.json', './yarn.lock']),


### PR DESCRIPTION
When editing a mustache file, Tilt doesn't currently detect the changes with this setup. This allow the demo to be a lot more slick since we can make mustache template changes and directly refresh the web page.